### PR TITLE
fix: ESLint deprecation warning and update to latest airbnb version

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "extends": "./index.js",
+  "rules": {
+    // disable requiring trailing commas because it might be nice to revert to
+    // being JSON at some point, and I don't want to make big changes now.
+    "comma-dangle": 0,
+    // we support node 4
+    "prefer-destructuring": 0,
+  },
+}

--- a/index.js
+++ b/index.js
@@ -7,29 +7,26 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
-    'plugin:ember/recommended'
-  ].concat([ './rules/best-practices',
+    'plugin:ember/recommended',
+    './rules/best-practices',
     './rules/errors',
     './rules/node',
     './rules/style',
     './rules/variables',
     './rules/es6',
     './rules/imports',
-  ].map(require.resolve)),
+  ].map(require.resolve),
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
     sourceType: 'module',
-    ecmaFeatures: {
-      experimentalObjectRestSpread: true,
-    },
   },
   plugins: [
     'ember'
   ],
   env: {
-    'browser': true,
-    'node': true,
-    'es6': true
+    browser: true,
+    node: true,
+    es6: true
   },
   rules: {
     strict: 'error',

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "eslint-config-rc-base",
-  "version": "12.1.0",
+  "version": "13.1.0",
   "description": "Airbnb's base JS ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {
     "prelint": "editorconfig-tools check * rules/* test/*",
     "lint": "eslint --report-unused-disable-directives .",
+    "pretests-only": "node ./test/requires",
     "tests-only": "babel-tape-runner ./test/test-*.js",
     "prepublish": "(in-install || eslint-find-rules --unused) && (not-in-publish || npm test) && safe-publish-latest",
     "pretest": "npm run --silent lint",
@@ -24,7 +25,11 @@
     "config",
     "airbnb",
     "javascript",
-    "styleguide"
+    "styleguide",
+    "es2015",
+    "es2016",
+    "es2017",
+    "es2018"
   ],
   "author": "Jake Teton-Landis (https://twitter.com/@jitl)",
   "contributors": [
@@ -48,24 +53,27 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
-    "babel-preset-airbnb": "^2.4.0",
+    "babel-preset-airbnb": "^2.5.3",
     "babel-tape-runner": "^2.0.1",
     "editorconfig-tools": "^0.1.1",
-    "eslint": "^4.12.1",
-    "eslint-find-rules": "^3.1.1",
+    "eslint": "^4.19.1 || ^5.3.0",
+    "eslint-find-rules": "^3.3.1",
     "eslint-plugin-ember": "^5.0.1",
-    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-import": "^2.16.0",
     "in-publish": "^2.0.0",
-    "safe-publish-latest": "^1.1.1",
-    "tape": "^4.8.0"
+    "safe-publish-latest": "^1.1.2",
+    "tape": "^4.10.1"
   },
   "peerDependencies": {
-    "eslint": "^4.12.1"
+    "eslint": "^4.19.1 || ^5.3.0",
+    "eslint-plugin-import": "^2.16.0"
   },
   "engines": {
     "node": ">= 4"
   },
   "dependencies": {
-    "eslint-restricted-globals": "^0.1.1"
+    "confusing-browser-globals": "^1.0.5",
+    "object.assign": "^4.1.0",
+    "object.entries": "^1.1.0"
   }
 }


### PR DESCRIPTION
Fixes deprecation warning:

```
[ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 
'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 
'parserOptions.ecmaVersion' instead. (found in "rc-base")
```